### PR TITLE
bugfix/accurics_remediation_7579285970001364 - Auto Generated Pull Request From Accurics

### DIFF
--- a/cft/misc/s3-bucket/test.tf
+++ b/cft/misc/s3-bucket/test.tf
@@ -1,10 +1,11 @@
 resource "aws_s3_bucket" "mybucket" {
   bucket = "mybucket"
-  acl = "public"
+  acl    = "public"
 
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
+        kms_master_key_id = "<kms_master_key_id>"
       }
     }
   }


### PR DESCRIPTION
**From Console:**

1. Login to AWS Management Console and open the Amazon S3 console using https://console.aws.amazon.com/s3/ 
2. Select the Check box next to the Bucket.
3. Click on 'Properties'.
4. Click on 'Default Encryption'.
5. Select either 'AES-256' or 'AWS-KMS'
6. Click 'Save'
7. Repeat for all the buckets in your AWS account lacking encryption.

**From Command Line:**

Run either 

aws s3api put-bucket-encryption --bucket <bucket name> --server-side-encryption-configuration '{"Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]}'

 or 

aws s3api put-bucket-encryption --bucket <bucket name> --server-side-encryption-configuration '{"Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "aws:kms","KMSMasterKeyID": "aws/s3"}}]}'


**Note:** the KMSMasterKeyID can be set to the master key of your choosing; aws/s3 is an AWS preconfigured default.